### PR TITLE
Open dashboard when selecting search result

### DIFF
--- a/src/ResultsWindow.js
+++ b/src/ResultsWindow.js
@@ -4,7 +4,7 @@ import "./App.css";
 
 const spring = { type: "spring", stiffness: 260, damping: 22, mass: 0.8 };
 
-function ResultsWindow({ results, disablePointerEvents }) {
+function ResultsWindow({ results, disablePointerEvents, onSelect }) {
   return (
     <motion.div
       className="results-window"
@@ -12,6 +12,7 @@ function ResultsWindow({ results, disablePointerEvents }) {
       animate={{ height: 540, opacity: 1, y: 0 }}
       exit={{ height: 0, opacity: 0, y: -20 }}
       transition={{ type: "spring", stiffness: 260, damping: 22, mass: 0.8 }}
+      style={{ pointerEvents: disablePointerEvents ? "none" : "auto" }}
     >
       <motion.div
         className="results-grid"
@@ -21,7 +22,7 @@ function ResultsWindow({ results, disablePointerEvents }) {
         style={{ WebkitAppRegion: "no-drag" }}
       >
         {results.map((video) => (
-          <VideoCard key={video.id} video={video} />
+          <VideoCard key={video.id} video={video} onSelect={onSelect} />
         ))}
       </motion.div>
     </motion.div>


### PR DESCRIPTION
## Summary
- show DashboardView when a user selects a video card
- resize Electron window based on dashboard or results state
- allow ResultsWindow to forward selection events and disable pointer events when dragging

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6890d2d9b38483259bcfa91cf6e004f8