### PR TITLE
Improve dropdown animation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -224,13 +224,15 @@ body{margin:0;background:transparent;font-family:"Inter",sans-serif}
 .dash-select-wrapper {
   position: relative;
   width: 100%;
-  transition: margin-bottom 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
+  transform: translateY(0);
+  transition:
+    margin-bottom 0.3s cubic-bezier(0.4, 0.0, 0.2, 1),
+    transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .dash-select-wrapper.dropdown-open + .dash-select-wrapper {
   position: relative;
-  top: 180px;
-  transition: top 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
+  transform: translateY(180px);
 }
 
 


### PR DESCRIPTION
## Summary
- Smooth the second dropdown shift with spring-like transform animation when the first dropdown opens

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6896491747908325b95272722d9a08c1